### PR TITLE
Server-Driven UI JSON 처리로직 작성

### DIFF
--- a/lib/datasource/accommodation/accommodation_datasource.dart
+++ b/lib/datasource/accommodation/accommodation_datasource.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_server_driven_ui/datasource/response_model/server_driven_ui/server_driven_ui_response.dart';
+
+abstract class AccommodationDataSource {
+  Future<ServerDrivenUIResponse> getAccommodationInformation();
+}

--- a/lib/datasource/response_model/server_driven_ui/screen_content.dart
+++ b/lib/datasource/response_model/server_driven_ui/screen_content.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_server_driven_ui/server_driven_ui/section_component_type.dart';
+
+const _id = 'id';
+const _sectionComponentType = 'sectionComponentType';
+const _section = 'section';
+
+class ScreenContent {
+  final String id;
+  final SectionComponentType sectionComponentType;
+  final Map<String, dynamic> section;
+
+  ScreenContent({
+    required this.id,
+    required this.sectionComponentType,
+    required this.section,
+  });
+
+  static ScreenContent fromJson(Map<String, dynamic> json) {
+    final String id = json[_id] as String;
+    final String sectionComponentTypeName =
+        json[_sectionComponentType] as String;
+    final SectionComponentType? sectionComponentType =
+        SectionComponentType.fromName(sectionComponentTypeName);
+
+    if (sectionComponentType == null) {
+      throw FormatException(
+          '잘못된 sectionComponentType 입니다 : $sectionComponentTypeName');
+    }
+
+    final Map<String, dynamic> section = json[_section] as Map<String, dynamic>;
+
+    return ScreenContent(
+      id: id,
+      sectionComponentType: sectionComponentType,
+      section: section,
+    );
+  }
+}

--- a/lib/datasource/response_model/server_driven_ui/server_driven_ui_response.dart
+++ b/lib/datasource/response_model/server_driven_ui/server_driven_ui_response.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_server_driven_ui/datasource/response_model/server_driven_ui/screen_content.dart';
+
+const _screenName = 'screenName';
+const _contents = 'contents';
+
+class ServerDrivenUIResponse {
+  final String screenName;
+  final List<ScreenContent> contentList;
+
+  ServerDrivenUIResponse({
+    required this.screenName,
+    required this.contentList,
+  });
+
+  static fromJson(Map<String, dynamic> json) {
+    final screenName =
+        json.containsKey(_screenName) ? json[_screenName] as String : '';
+    final contents =
+        json.containsKey(_contents) ? json[_contents] as List<dynamic> : [];
+
+    List<ScreenContent> contentList = contents.map<ScreenContent>((element) {
+      return ScreenContent.fromJson(element as Map<String, dynamic>);
+    }).toList();
+
+    return ServerDrivenUIResponse(
+      screenName: screenName,
+      contentList: contentList,
+    );
+  }
+}

--- a/lib/server_driven_ui/section_component_type.dart
+++ b/lib/server_driven_ui/section_component_type.dart
@@ -1,0 +1,18 @@
+enum SectionComponentType {
+  title('TITLE'),
+  plusTitle('PLUS_TITLE');
+
+  const SectionComponentType(this.name);
+
+  final String name;
+
+  static final Map<String, SectionComponentType> _componentTypeMap =
+      values.asMap().map((_, type) => MapEntry(type.name, type));
+
+  static SectionComponentType? fromName(String name) {
+    // json에 있는 문자열 sectionComponentType을 enum으로 변환하는데
+    // dart 기본으로 가능한 것은 enum list를 순회하면서 찾는 방법이라서
+    // 성능을 위해서 Map으로 변환해서 사용합니다
+    return _componentTypeMap[name];
+  }
+}


### PR DESCRIPTION
server driven ui 구현을 위한 데이터 객체(`ScreenContent`, `ServerDrivenUIResponse`) 랑 API 응답 처리 로직을 추가했습니다
기본 틀을 만들어 놓는데 집중해서 세부로직은 아직 없습니다

```json
{
    "screenName": "Home",
    "contents": [
        {
            "id": "title_section",
            "sectionComponentType": "TITLE",
            "section": {
                "type": "TitleSection",
                "title": "Seamist Beach Cottage, Private Beach & Ocean Views",
                "badges": [
                    {
                        "badgeImage": "https://icon.airbnb.com/startRating.png",
                        "text": "4.79(99 reviews)"
                    }
                ],
                "description": "Bodega Bay, California, United States"
            }
        },
        {
            "id": "title_section",
            "sectionComponentType": "PLUS_TITLE",
            "section": {
                "type": "PlusTitleSection",
                "firstRowImage": {
                    "imgUrl": "https://icon.airbnb.com/airbnbPlusMembership.png",
                    "width": "40",
                    "height": "25"
                },
                "titleText": {
                    "text": "Rancho Tranquillo Rustic ChicTent",
                    "textSize": "16",
                    "textColor": "#FF0000",
                    "textStyle": "bold | italic | strike"
                },
                "badges": [
                    {
                        "badgeImage": "https://icon.airbnb.com/startRating.png",
                        "text": "4.79(105 reviews)"
                    },
                    {
                        "badgeImage": "https://icon.airbnb.com/superHost.png",
                        "text": "Superhost"
                    }
                ],
                "description": "San Juan Bautista, California, United States"
            }
        }
    ]
}
```

## ScreenContent
화면에 표시될 UI 구성 요소
json에서 `contents`에 대응하는 부분입니다

속성으로 `section`를 가지고 있는데 이거는 json에서 그대로 section map에 대응하는 곳입니다

## ServerDrivenUIResponse
서버에서 받은 UI 구성 정보를 담는 클래스

```dart
// json: 서버에서 받은 RAW값
ServerDrivenUIResponse response = ServerDrivenUIResponse.fromJson(json);
```

repository에서 `response.contentList`를 가지고 dart value object로 변환하면 됩니다

## SectionComponentType
UI 구성 요소의 유형을 정의하는 enum입니다
json에서 sectionComponentType에 대응합니다

```dart
SectionComponentType type = SectionComponentType.fromName('TITLE');
```

## AccommodationDataSource
예시 json에 맞게 만들어 놓은 숙소 정보를 가져오는 데이터 소스 인터페이스입니다
구현은 추후 진행 예정입니다

## 추가로 해야할 것들

- 서버 API 연동 로직 구현
- json 상태에 따라 오류를 탐지하여 디폴트 값 등으로 대응하는 로직 추가